### PR TITLE
bug with path argument

### DIFF
--- a/lev
+++ b/lev
@@ -18,10 +18,7 @@ var location = process.argv[2];
 if (location && location[0] === '-') {
   location = process.cwd();
 }
-else if (location) {
-  location = process.argv.splice(2, 1);
-}
-else {
+else if (!location) {
   location = process.cwd();
 }
 


### PR DESCRIPTION
magnus@desktop|22:18|/tmp $ lev level-npm-basic/

path.js:360
        throw new TypeError('Arguments to path.join must be strings');
              ^
TypeError: Arguments to path.join must be strings
    at path.js:360:15
    at Array.filter (native)
    at Object.exports.join (path.js:358:36)
    at Object.<anonymous> (/home/magnus/src/lev/lev:98:16)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
