### PR TITLE
save .lev_history in non write protected directory

### DIFF
--- a/lev
+++ b/lev
@@ -660,7 +660,7 @@ function lev(db) {
       path.join(__dirname, 'node_modules', 'levelup', 'package.json')
     ).version
 
-    var historyFile = path.join(__dirname, '.lev_history')
+    var historyFile = path.join(location, '.lev_history')
 
     write([
       


### PR DESCRIPTION
the global node_modules folder often is read-only for non-roots.
