### PR TITLE
level@0.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "commandline and REPL access for leveldb",
   "main": "lev",
   "dependencies": {
-    "level": "~0.16.0",
+    "level": "~0.17.0",
     "optimist": "0.3.4",
     "deepmerge": "~0.2.5",
     "level-delete-range": "0.1.0",


### PR DESCRIPTION
This allows to open the new db files with the new ending (.ldb instead of .sst) that level 0.17.0 is using
