### PR TITLE
Update level-sublevel to major 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "level": "0.18.0",
     "level-delete-range": "0.1.0",
     "level-manifest": "~1.2.0",
-    "level-sublevel": "~4.8.0",
+    "level-sublevel": "^6.3.15",
     "level-subtree": "~1.1.1",
     "multilevel": "^6.0.0",
     "optimist": "0.3.4",


### PR DESCRIPTION
This is incomplete, but I'd love to talk about ways to keep backward compatibility.

`level-sublevel` has added a "legacy" mode which might be nice to emulate -- a `--legacy` command line flag, perhaps?

`level-subtree` will also have to be updated to make this work.
