### PR TITLE
Use shlex.js to parse params in PUT properly

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -8,6 +8,7 @@ var REPL = require('repl');
 var print = require('./print');
 var xtend = require('xtend');
 var Tabulate = require('tabulate');
+var shlexJs = require("shlex.js");
 
 var tabulate = Tabulate(process.stdout);
 
@@ -63,7 +64,7 @@ module.exports = function(db, config, cache) {
   repl.context.put =
   repl.context.PUT = function(opts, callback) {
 
-    var args = opts.rest.split(/\s+/);
+    var args = shlexJs.split(opts.rest)
     var key = args[0];
     args.shift();
     var val = args.join(' ');

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "minimist": "^1.1.0",
     "multilevel": "^7.3.0",
     "rc": "^0.5.4",
+    "shlex.js": "0.0.1",
     "tabulate": "^1.0.0",
     "xtend": "^4.0.0"
   }


### PR DESCRIPTION
Allows for escaped or quotes keys with space. 

`PUT "key key key" test test test` will create key 'key key key' with value 'test test test'.
`PUT "key key key" test \"quote\" test` will create key 'key key key' with value 'test "quote" test'.

It most likely screws up with JSON data (may require manual escaping of double quotes) but it's just something i done very fast since I had to edit manually key with spaces in it.