### PR TITLE
refactoring CLI commands and documenting

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,15 @@ lev --del foo
 ```
 
 ## --batch &lt;operations&gt;
+Put or delete several values, using [`levelup` batch syntax](https://github.com/Level/levelup#dbbatcharray-options-callback-array-form)
 ```sh
-lev --batch '[{"type":"del","key":"father"},{"type":"put","key":"name","value":"Yuri Irsenovich Kim"},{"type":"put","key":"dob","value":"16 February 1941"},{"type":"put","key":"spouse","value":"Kim Young-sook"},{"type":"put","key":"occupation","value":"Clown"}]'
+lev --batch '[
+{"type":"del","key":"father"},
+{"type":"put","key":"name","value":"Yuri Irsenovich Kim"},
+{"type":"put","key":"dob","value":"16 February 1941"},
+{"type":"put","key":"spouse","value":"Kim Young-sook"},
+{"type":"put","key":"occupation","value":"Clown"}
+]'
 ```
 
 ## --keys

--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ Emit as a new-line delimited stream of json.
 lev --values
 ```
 
-## --stream
+## --all
 List all the keys and values in the current range.
 Emit as a new-line delimited stream of json.
 ```sh
-lev --stream
+lev --all
 ```
 
 ## --start &lt;key-pattern&gt;

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ lev --batch '[
 ```
 or from a file
 ```sh
+# there should be one entry per line
+# either as valid JSON
 echo '[
 {"type":"del","key":"father"},
 {"type":"put","key":"name","value":"Yuri Irsenovich Kim"},
@@ -95,7 +97,27 @@ echo '[
 {"type":"put","key":"spouse","value":"Kim Young-sook"},
 {"type":"put","key":"occupation","value":"Clown"}
 ]' > ops.json
+# or as newline-delimited JSON
+echo '
+{"type":"del","key":"father"}
+{"type":"put","key":"name","value":"Yuri Irsenovich Kim"}
+{"type":"put","key":"dob","value":"16 February 1941"}
+{"type":"put","key":"spouse","value":"Kim Young-sook"}
+{"type":"put","key":"occupation","value":"Clown"}
+' > ops.json
 lev --batch ./ops.json
+```
+
+If the type is omitted, defaults to `put`, which allows to use the command to do imports/exports, in combination with [`--all`](#--all):
+```sh
+lev --all > leveldb.export
+lev /tmp/my-new-db --batch leveldb.export
+```
+If it's a large export, you can compress it on the fly
+```sh
+lev --all | gzip -9 > leveldb.export.gz
+gzip -dk leveldb.export.gz
+lev /tmp/my-new-db --batch leveldb.export
 ```
 
 ## --keys
@@ -116,6 +138,11 @@ List all the keys and values in the current range.
 Emit as a new-line delimited stream of json.
 ```sh
 lev --all
+```
+It can be used to create an export of the database, to be imported with [`--batch`](#--batch)
+```sh
+lev --all > leveldb.export
+lev /tmp/my-new-db --batch leveldb.export
 ```
 
 ## --start &lt;key-pattern&gt;

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ echo '
 lev --batch ./ops.json
 ```
 
+### Import / Export
 If the type is omitted, defaults to `put`, which allows to use the command to do imports/exports, in combination with [`--all`](#--all):
 ```sh
 lev --all > leveldb.export
@@ -118,6 +119,15 @@ If it's a large export, you can compress it on the fly
 lev --all | gzip -9 > leveldb.export.gz
 gzip -dk leveldb.export.gz
 lev /tmp/my-new-db --batch leveldb.export
+```
+
+### Delete by range
+The `--batch` option can also be used to delete key/values by range in 2 steps:
+```
+# 1 - collect all the key/values to delete
+lev --all --start 'foo' --end 'fooz' > ./to_delete
+# 2 - pass the file as argument to the --batch option with a --del flag
+lev --batch ./to_delete --del
 ```
 
 ## --keys

--- a/README.md
+++ b/README.md
@@ -79,4 +79,6 @@ Limit the number of records emitted in the current range.
 ## --reverse
 Reverse the stream.
 
+## --line
+Output one key per line
 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,6 @@ Emit as a new-line delimited stream of json.
 ## --keys
 Only list all of the keys in the current range. Will tabularize the output.
 
-## --keyEncoding &lt;string&gt;
-Specify the encoding for the keys.
-
 ## --valueEncoding &lt;string&gt;
 Specify the encoding for the values.
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Filter keys or values by a pattern applied on the key
 ```sh
 lev  --keys --match 'f*'
 lev  --values --match 'f*'
+lev  --all --match 'f*'
 # Equivalent to
 lev --match 'f*'
 ```

--- a/README.md
+++ b/README.md
@@ -156,6 +156,15 @@ Output one key per line (instead of the default tabularized output)
 lev --keys --line
 ```
 
+## --length
+Output the length of the current range
+```sh
+# Output the length of the whole database
+lev --length
+# Counts the keys and values between 'foo' and 'fooz'
+lev --start 'foo' --end 'fooz' --length
+```
+
 ## --valueEncoding &lt;string&gt;
 Specify the encoding for the values (Defaults to 'json').
 ```sh

--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ lev --batch '[
 {"type":"put","key":"occupation","value":"Clown"}
 ]'
 ```
+or from a file
+```sh
+echo '[
+{"type":"del","key":"father"},
+{"type":"put","key":"name","value":"Yuri Irsenovich Kim"},
+{"type":"put","key":"dob","value":"16 February 1941"},
+{"type":"put","key":"spouse","value":"Kim Young-sook"},
+{"type":"put","key":"occupation","value":"Clown"}
+]' > ops.json
+lev --batch ./ops.json
+```
 
 ## --keys
 List all the keys in the current range. Will tabularize the output by default (see `--line`).

--- a/README.md
+++ b/README.md
@@ -234,3 +234,21 @@ lev --location /tmp/test-db --keys
 # Equivalent to
 lev /tmp/test-db --keys
 ```
+
+## --map &lt;JS function string or path&gt;
+Pass streams results in a map function
+* either inline
+```sh
+lev --keys --map 'key => key.split(":")[1]'
+lev --all --map 'data => data.value.replace(data.key, "")'
+```
+* or from a JS file that exports a function
+```js
+# in ./map_fn.js
+module.exports = key => key.split(":")[1]
+```
+```sh
+lev --keys --map ./map_fn.js
+```
+
+If the function, returns null or undefined, the result is filtered-out

--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ Emit as a new-line delimited stream of json.
 lev --values
 ```
 
+## --stream
+List all the keys and values in the current range.
+Emit as a new-line delimited stream of json.
+```sh
+lev --stream
+```
+
 ## --start &lt;key-pattern&gt;
 Specify the start of the current range. You can also use `gt` or `gte`.
 ```sh

--- a/README.md
+++ b/README.md
@@ -57,28 +57,108 @@ These all match the parameters used with
 [`levelup`](https://github.com/rvagg/node-levelup). The default encoding
 for the database is set to `json`.
 
+## --get &lt;key&gt;
+Get a value
+```sh
+lev --get foo
+```
+
+## --put &lt;key&gt;
+Put a value
+```sh
+lev --put foo --value bar
+```
+
+## --del &lt;key&gt;
+Delete a value
+```sh
+lev --del foo
+```
+
+## --batch &lt;operations&gt;
+```sh
+lev --batch '[{"type":"del","key":"father"},{"type":"put","key":"name","value":"Yuri Irsenovich Kim"},{"type":"put","key":"dob","value":"16 February 1941"},{"type":"put","key":"spouse","value":"Kim Young-sook"},{"type":"put","key":"occupation","value":"Clown"}]'
+```
+
+## --keys
+List all the keys in the current range. Will tabularize the output by default (see `--line`).
+```sh
+lev --keys
+```
+
+## --values
+List all the values in the current range.
+Emit as a new-line delimited stream of json.
+```sh
+lev --values
+```
+
 ## --start &lt;key-pattern&gt;
 Specify the start of the current range. You can also use `gt` or `gte`.
+```sh
+# output all keys after 'foo'
+lev --keys --start 'foo'
+# which is equivalent to
+lev --keys --gte 'foo'
+# the same for values
+lev --values --start 'foo'
+```
 
 ## --end &lt;key-pattern&gt;
 Specify the end of the current range. You can also use `lt` and `lte`.
+```sh
+# output all keys before 'fooz'
+lev --keys --end 'fooz'
+# which is equivalent to
+lev --keys --lte 'fooz'
+# the same for values
+lev --values --end 'fooz'
+# output all keys between 'foo' and 'fooz'
+lev --keys --start 'foo' --end 'fooz'
+```
 
-## --values
-Only list the all of the values in the current range.
-Emit as a new-line delimited stream of json.
+## --match &lt;key-pattern&gt;
+Filter keys or values by a pattern applied on the key
+```sh
+lev  --keys --match 'f*'
+lev  --values --match 'f*'
+# Equivalent to
+lev --match 'f*'
+```
 
-## --keys
-Only list all of the keys in the current range. Will tabularize the output.
-
-## --valueEncoding &lt;string&gt;
-Specify the encoding for the values.
+See [`minimatch` doc](https://github.com/isaacs/minimatch#readme) for patterns
 
 ## --limit &lt;number&gt;
 Limit the number of records emitted in the current range.
+```sh
+lev --keys --limit 10
+lev --values --start 'foo' --end 'fooz' --limit 100
+lev --match 'f*' --limit 10
+```
 
 ## --reverse
 Reverse the stream.
+```sh
+lev --keys --reverse
+lev --keys --start 'foo' --end 'fooz' --limit 100 --reverse
+```
 
 ## --line
-Output one key per line
+Output one key per line (instead of the default tabularized output)
+```sh
+lev --keys --line
+```
 
+## --valueEncoding &lt;string&gt;
+Specify the encoding for the values (Defaults to 'json').
+```sh
+lev --values --valueEncoding buffer
+```
+
+## --location &lt;string&gt;
+Specify the path to the LevelDB to use. Defaults to the current directory.
+```sh
+lev --location /tmp/test-db --keys
+# Equivalent to
+lev /tmp/test-db --keys
+```

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ lev --keys --line
 ## --length
 Output the length of the current range
 ```sh
-# Output the length of the whole database
+# Count all the key/value pairs in the database
 lev --length
 # Counts the keys and values between 'foo' and 'fooz'
 lev --start 'foo' --end 'fooz' --length

--- a/index.js
+++ b/index.js
@@ -12,7 +12,16 @@ module.exports = function(args) {
   // find where the location by examining the arguments
   // and create an instance to work with.
   //
-  locate(args);
+  locate(args, function (err) {
+    if (err) {
+      console.error(err);
+      return process.exit(1);
+    }
+    init(args);
+  });
+};
+
+function init (args) {
   var db = getDB(args);
 
   //
@@ -39,6 +48,5 @@ module.exports = function(args) {
 
   history(repl, args);
   completion(repl, cache);
-
 };
 

--- a/index.js
+++ b/index.js
@@ -21,13 +21,13 @@ module.exports = function(args) {
   //
   var cliCommands = [
     'keys', 'values', 'get', 'match',
-    'put', 'del', 'all', 'batch'
+    'put', 'del', 'all', 'batch', 'length'
   ];
-  
+
   var cliMode = Object.keys(args).some(function(cmd) {
     return cliCommands.indexOf(cmd) > -1;
   });
- 
+
   if (cliMode) {
     return cli(db, args);
   }

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = function(args) {
   //
   var cliCommands = [
     'keys', 'values', 'get', 'match',
-    'put', 'del', 'createReadStream', 'batch'
+    'put', 'del', 'stream', 'batch'
   ];
   
   var cliMode = Object.keys(args).some(function(cmd) {

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = function(args) {
   //
   var cliCommands = [
     'keys', 'values', 'get', 'match', 'put', 'del',
-    'all', 'batch', 'length', 'start', 'end', 'limit'
+    'all', 'batch', 'length', 'start', 'end', 'limit', 'map'
   ];
 
   var cliMode = Object.keys(args).some(function(cmd) {

--- a/index.js
+++ b/index.js
@@ -20,8 +20,8 @@ module.exports = function(args) {
   // than the program should not be run in REPL mode.
   //
   var cliCommands = [
-    'keys', 'values', 'get', 'match',
-    'put', 'del', 'all', 'batch', 'length'
+    'keys', 'values', 'get', 'match', 'put', 'del',
+    'all', 'batch', 'length', 'start', 'end', 'limit'
   ];
 
   var cliMode = Object.keys(args).some(function(cmd) {

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = function(args) {
   //
   var cliCommands = [
     'keys', 'values', 'get', 'match',
-    'put', 'del', 'stream', 'batch'
+    'put', 'del', 'all', 'batch'
   ];
   
   var cliMode = Object.keys(args).some(function(cmd) {

--- a/lib/batch_from_file.js
+++ b/lib/batch_from_file.js
@@ -1,0 +1,52 @@
+var fs = require('fs');
+var path = require('path');
+var split = require('split');
+var printAndExit = require('./print_and_exit');
+
+module.exports = function(db, file) {
+  var batch = [];
+  var total = 0;
+
+  fs.createReadStream(path.resolve(file))
+  .pipe(split())
+  .on('data', function(line) {
+    if (line[0] !== '{') return
+    line = line.replace(/,$/, '')
+
+    //
+    // add each line to the batch
+    //
+    var entry = JSON.parse(line);
+    entry.type = entry.type || 'put';
+    batch.push(entry)
+
+    //
+    // run operations by batches of 10000 entries
+    //
+    if (batch.length >= 10000) {
+      var stream = this;
+      stream.pause();
+      db.batch(batch, function(err, val) {
+        if (err) return printAndExit(err, val);
+        total += batch.length
+        console.log('ops run:', total)
+        batch = [];
+        stream.resume();
+      })
+    }
+
+  })
+  .on('close', function() {
+    if (batch.length > 0) {
+      db.batch(batch, function(err, val) {
+        if (err) return printAndExit(err, val);
+        total += batch.length;
+        console.log('total ops:', total)
+      });
+    }
+    else {
+      console.log('total ops:', total)
+    }
+  })
+}
+

--- a/lib/batch_from_file.js
+++ b/lib/batch_from_file.js
@@ -3,7 +3,7 @@ var path = require('path');
 var split = require('split');
 var printAndExit = require('./print_and_exit');
 
-module.exports = function(db, file) {
+module.exports = function(db, file, del) {
   var batch = [];
   var total = 0;
 
@@ -17,7 +17,7 @@ module.exports = function(db, file) {
     // add each line to the batch
     //
     var entry = JSON.parse(line);
-    entry.type = entry.type || 'put';
+    entry.type = del ? 'del' : (entry.type || 'put');
     batch.push(entry)
 
     //

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,6 +1,6 @@
 /*
  *
- * cahce.js
+ * cache.js
  * save the keys from the readstream into an
  * array so that they can be autocompleted and suggested.
  *

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -80,7 +80,8 @@ module.exports = function(db, args) {
       .on('end', process.exit);
   }
   else if (args.batch) {
-    db.batch(args.batch, printAndExit)
+    var batch = JSON.parse(args.batch)
+    db.batch(batch, printAndExit)
   }
   else if (args.del) {
     db.del(args.key || args.del, printAndExit)

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -17,6 +17,8 @@ module.exports = function(db, args) {
 
     if (args.values) args.keys = false;
     if (args.keys) args.values = false;
+    if (args.start) args.gte = args.start
+    if (args.end) args.lte = args.end
 
     var items = [];
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -83,6 +83,22 @@ module.exports = function(db, args) {
         process.exit(exitCode);
       });
   }
+  // Test args.batch before args.del to be able to pass a --del flag
+  // to the --batch option
+  else if (args.batch) {
+    if (args.batch[0] !== '[') {
+      require('./batch_from_file')(db, args.batch, args.del)
+      return
+    }
+    var batch = JSON.parse(args.batch);
+    if (args.del) {
+      batch = batch.map(op => {
+        op.type = 'del'
+        return op
+      });
+    }
+    db.batch(batch, printAndExit);
+  }
   else if (args.put) {
     db.put(args.key || args.put, args.value, printAndExit);
   }
@@ -91,14 +107,6 @@ module.exports = function(db, args) {
   }
   else if (args.del) {
     db.del(args.key || args.del, printAndExit);
-  }
-  else if (args.batch) {
-    if (args.batch[0] !== '[') {
-      require('./batch_from_file')(db, args.batch)
-      return
-    }
-    var batch = JSON.parse(args.batch);
-    db.batch(batch, printAndExit);
   }
   else {
     printAndExit(new Error('No valid command'));

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -60,9 +60,15 @@ module.exports = function(db, args) {
     db.get(args.key || args.get, printAndExit)
   }
   else if (args.match) {
+    var limit = typeof args.limit === 'number' ? args.limit : Infinity
+    var count = 0
+    delete args.limit
     db.createReadStream(args)
       .on('data', function(data) {
         if (!minimatch(data.key, args.match)) return;
+        if (++count > limit) {
+          return process.exit()
+        }
         if (!args.valueEncoding ||
           args.valueEncoding == 'json') {
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -9,8 +9,6 @@ var Tabulate = require('tabulate');
 var print = require('./print');
 var minimatch = require("minimatch");
 
-var tabulate = Tabulate(process.stdout);
-
 module.exports = function(db, args) {
 
   if (args.values || args.keys) {
@@ -20,13 +18,21 @@ module.exports = function(db, args) {
     if (args.start) args.gte = args.start
     if (args.end) args.lte = args.end
 
-    var items = [];
+    if (!args.line) {
+      var tabulate = Tabulate(process.stdout);
+      var items = [];
+    }
 
     db
       .createReadStream(args)
       .on('data', function(data) {
         if (args.keys) {
-          return items.push(data);
+          if (args.line) {
+            process.stdout.write(data + '\n')
+          }
+          else {
+            items.push(data);
+          }
         }
         else if (!args.valueEncoding ||
           args.valueEncoding == 'json') {
@@ -37,7 +43,7 @@ module.exports = function(db, args) {
         }
       })
       .on('end', function() {
-        if (args.keys) {
+        if (args.keys && !args.line) {
           process.stdout.write(tabulate.write(items))
         }
         process.exit(0);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -48,6 +48,9 @@ module.exports = function(db, args) {
       delete args.keys;
       delete args.limit;
     }
+    else if (args.map) {
+      delete args.limit;
+    }
     else if (args.length) {
       args.keys = true
     }
@@ -82,7 +85,10 @@ module.exports = function(db, args) {
 
         if (args.map) {
           data = mapFn(data)
-          if (data == null) return
+          if (data == null) {
+            count--
+            return
+          }
         }
 
         if (tabulate) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -94,7 +94,8 @@ module.exports = function(db, args) {
   }
   else if (args.batch) {
     if (args.batch[0] !== '[') {
-      args.batch = require('fs').readFileSync(args.batch).toString()
+      require('./batch_from_file')(db, args.batch)
+      return
     }
     var batch = JSON.parse(args.batch);
     db.batch(batch, printAndExit);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -20,12 +20,21 @@ module.exports = function(db, args) {
 
     var values = args.values;
     var keys = args.keys;
-    delete args.values;
-    delete args.keys;
-
     var limit = typeof args.limit === 'number' ? args.limit : Infinity;
     var count = 0;
-    delete args.limit;
+
+    if (args.match) {
+      delete args.values;
+      delete args.keys;
+      delete args.limit;
+    }
+    else if (args.length) {
+      args.keys = true
+    }
+
+    if (args.keys) args.values = false
+    if (args.values) args.keys = false
+
 
     var tabulate;
     if (keys && !args.line) {
@@ -46,8 +55,10 @@ module.exports = function(db, args) {
           return
         }
 
-        if (keys) data = data.key;
-        if (values) data = data.value;
+        if (args.match) {
+          if (keys) data = data.key;
+          if (values) data = data.value;
+        }
 
         if (tabulate) {
           items.push(data);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -48,7 +48,7 @@ module.exports = function(db, args) {
           if (items.length === 0) {
             return process.exit(1);
           }
-          process.stdout.write(tabulate.write(items))
+          process.stdout.write(tabulate.write(items).trim() + '\n')
         }
         process.exit(0);
       });

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -7,6 +7,7 @@
  */
 var Tabulate = require('tabulate');
 var print = require('./print');
+var printAndExit = require('./print_and_exit');
 var minimatch = require("minimatch");
 
 module.exports = function(db, args) {
@@ -44,16 +45,19 @@ module.exports = function(db, args) {
       })
       .on('end', function() {
         if (args.keys && !args.line) {
+          if (items.length === 0) {
+            return process.exit(1);
+          }
           process.stdout.write(tabulate.write(items))
         }
         process.exit(0);
       });
   }
   else if (args.put) {
-    db.put(args.key || args.put, args.value, print)
+    db.put(args.key || args.put, args.value, printAndExit)
   }
   else if (args.get) {
-    db.get(args.key || args.get, print)
+    db.get(args.key || args.get, printAndExit)
   }
   else if (args.match) {
     db.createReadStream(args)
@@ -76,13 +80,13 @@ module.exports = function(db, args) {
       .on('end', process.exit);
   }
   else if (args.batch) {
-    db.batch(args.batch, print)
+    db.batch(args.batch, printAndExit)
   }
   else if (args.del) {
-    db.del(args.key || args.del, print)
+    db.del(args.key || args.del, printAndExit)
   }
   else {
-    print(null, 'No valid command');
+    printAndExit(new Error('No valid command'));
   }
 };
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -11,75 +11,56 @@ var printAndExit = require('./print_and_exit');
 var minimatch = require("minimatch");
 
 module.exports = function(db, args) {
-  if (args.start) args.gte = args.start;
-  if (args.end) args.lte = args.end;
 
-  var valueEncoding = args.valueEncoding || 'json';
+  if (args.all || args.values || args.keys || args.match) {
 
-  if (args.values || args.keys) {
+    var valueEncoding = args.valueEncoding || 'json';
+    if (args.start) args.gte = args.start;
+    if (args.end) args.lte = args.end;
 
-    if (args.values) args.keys = false;
-    if (args.keys) args.values = false;
+    var values = args.values;
+    var keys = args.keys;
+    delete args.values;
+    delete args.keys;
 
-    if (!args.line) {
-      var tabulate = Tabulate(process.stdout);
+    var limit = typeof args.limit === 'number' ? args.limit : Infinity;
+    var count = 0;
+    delete args.limit;
+
+    var tabulate;
+    if (keys && !args.line) {
+      tabulate = Tabulate(process.stdout);
       var items = [];
     }
 
-    db
-      .createReadStream(args)
+    db.createReadStream(args)
       .on('data', function(data) {
-        if (args.keys) {
-          if (args.line) {
-            process.stdout.write(data + '\n');
-          }
-          else {
-            items.push(data);
-          }
+        if (args.match && !minimatch(data.key, args.match)) return;
+        if (++count > limit) {
+          return this.emit('end');
+        }
+        if (keys) data = data.key;
+        if (values) data = data.value;
+
+        if (tabulate) {
+          items.push(data);
         }
         else if (valueEncoding === 'json') {
-          process.stdout.write(JSON.stringify(data) + '\n');
+          if (typeof data !== 'string') data = JSON.stringify(data);
+          return process.stdout.write(data + '\n');
         }
         else {
           process.stdout.write(data);
         }
       })
+      .on('error', print)
       .on('end', function() {
-        if (args.keys && !args.line) {
-          if (items.length === 0) {
-            return process.exit(1);
-          }
+        if (tabulate && items.length > 0) {
           process.stdout.write(tabulate.write(items).trim() + '\n');
         }
-        process.exit(0);
+        var exitCode = count > 0 ? 0 : 1
+        process.exit(exitCode);
       });
-  }
-  else if (args.match) {
-    var limit = typeof args.limit === 'number' ? args.limit : Infinity
-    var count = 0
-    delete args.limit
-    db.createReadStream(args)
-      .on('data', function(data) {
-        if (!minimatch(data.key, args.match)) return;
-        if (++count > limit) {
-          return process.exit();
-        }
-        if (valueEncoding === 'json') {
-          return process.stdout.write(
-            JSON.stringify(data) + '\n'
-          );
-        }
-        print(null, data.value);
-      })
-      .on('end', process.exit);
-  }
-  else if (args.stream) {
-    db.createReadStream(args)
-      .on('data', function(data) {
-        process.stdout.write(JSON.stringify(data) + '\n');
-      })
-      .on('error', print)
-      .on('end', process.exit);
   }
   else if (args.put) {
     db.put(args.key || args.put, args.value, printAndExit);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -11,13 +11,13 @@ var printAndExit = require('./print_and_exit');
 var minimatch = require("minimatch");
 
 module.exports = function(db, args) {
+  if (args.start) args.gte = args.start
+  if (args.end) args.lte = args.end
 
   if (args.values || args.keys) {
 
     if (args.values) args.keys = false;
     if (args.keys) args.values = false;
-    if (args.start) args.gte = args.start
-    if (args.end) args.lte = args.end
 
     if (!args.line) {
       var tabulate = Tabulate(process.stdout);
@@ -76,13 +76,16 @@ module.exports = function(db, args) {
             JSON.stringify(data) + '\n'
           );
         }
-        print(err, data.value);
+        print(null, data.value);
       })
       .on('end', process.exit);
   }
-  else if (args.createReadStream) {
+  else if (args.stream) {
     db.createReadStream(args)
-      .on('data', print)
+      .on('data', function(data) {
+        process.stdout.write(JSON.stringify(data) + '\n')
+      })
+      .on('error', print)
       .on('end', process.exit);
   }
   else if (args.batch) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -10,9 +10,17 @@ var print = require('./print');
 var printAndExit = require('./print_and_exit');
 var minimatch = require("minimatch");
 
+var hasStreamArg = function(args) {
+  return args.all || args.values || args.keys || args.match || args.length
+}
+
 module.exports = function(db, args) {
 
-  if (args.all || args.values || args.keys || args.match || args.length) {
+  if (!hasStreamArg(args) && (args.start || args.end || args.limit)) {
+    args.all = true
+  }
+
+  if (hasStreamArg(args)) {
 
     var valueEncoding = args.valueEncoding || 'json';
     if (args.start) args.gte = args.start;

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -12,7 +12,7 @@ var minimatch = require("minimatch");
 
 module.exports = function(db, args) {
 
-  if (args.all || args.values || args.keys || args.match) {
+  if (args.all || args.values || args.keys || args.match || args.length) {
 
     var valueEncoding = args.valueEncoding || 'json';
     if (args.start) args.gte = args.start;
@@ -36,9 +36,16 @@ module.exports = function(db, args) {
     db.createReadStream(args)
       .on('data', function(data) {
         if (args.match && !minimatch(data.key, args.match)) return;
+
         if (++count > limit) {
+          count--
           return this.emit('end');
         }
+
+        if (args.length) {
+          return
+        }
+
         if (keys) data = data.key;
         if (values) data = data.value;
 
@@ -47,7 +54,7 @@ module.exports = function(db, args) {
         }
         else if (valueEncoding === 'json') {
           if (typeof data !== 'string') data = JSON.stringify(data);
-          return process.stdout.write(data + '\n');
+          process.stdout.write(data + '\n');
         }
         else {
           process.stdout.write(data);
@@ -55,7 +62,10 @@ module.exports = function(db, args) {
       })
       .on('error', print)
       .on('end', function() {
-        if (tabulate && items.length > 0) {
+        if (args.length){
+          process.stdout.write(count + '\n');
+        }
+        else if (tabulate && items.length > 0) {
           process.stdout.write(tabulate.write(items).trim() + '\n');
         }
         var exitCode = count > 0 ? 0 : 1

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -11,10 +11,10 @@ var printAndExit = require('./print_and_exit');
 var minimatch = require("minimatch");
 
 module.exports = function(db, args) {
-  if (args.start) args.gte = args.start
-  if (args.end) args.lte = args.end
+  if (args.start) args.gte = args.start;
+  if (args.end) args.lte = args.end;
 
-  var valueEncoding = args.valueEncoding || 'json'
+  var valueEncoding = args.valueEncoding || 'json';
 
   if (args.values || args.keys) {
 
@@ -31,7 +31,7 @@ module.exports = function(db, args) {
       .on('data', function(data) {
         if (args.keys) {
           if (args.line) {
-            process.stdout.write(data + '\n')
+            process.stdout.write(data + '\n');
           }
           else {
             items.push(data);
@@ -49,7 +49,7 @@ module.exports = function(db, args) {
           if (items.length === 0) {
             return process.exit(1);
           }
-          process.stdout.write(tabulate.write(items).trim() + '\n')
+          process.stdout.write(tabulate.write(items).trim() + '\n');
         }
         process.exit(0);
       });
@@ -62,7 +62,7 @@ module.exports = function(db, args) {
       .on('data', function(data) {
         if (!minimatch(data.key, args.match)) return;
         if (++count > limit) {
-          return process.exit()
+          return process.exit();
         }
         if (valueEncoding === 'json') {
           return process.stdout.write(
@@ -76,23 +76,23 @@ module.exports = function(db, args) {
   else if (args.stream) {
     db.createReadStream(args)
       .on('data', function(data) {
-        process.stdout.write(JSON.stringify(data) + '\n')
+        process.stdout.write(JSON.stringify(data) + '\n');
       })
       .on('error', print)
       .on('end', process.exit);
   }
   else if (args.put) {
-    db.put(args.key || args.put, args.value, printAndExit)
+    db.put(args.key || args.put, args.value, printAndExit);
   }
   else if (args.get) {
-    db.get(args.key || args.get, printAndExit)
+    db.get(args.key || args.get, printAndExit);
   }
   else if (args.del) {
-    db.del(args.key || args.del, printAndExit)
+    db.del(args.key || args.del, printAndExit);
   }
   else if (args.batch) {
-    var batch = JSON.parse(args.batch)
-    db.batch(batch, printAndExit)
+    var batch = JSON.parse(args.batch);
+    db.batch(batch, printAndExit);
   }
   else {
     printAndExit(new Error('No valid command'));

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -14,6 +14,8 @@ module.exports = function(db, args) {
   if (args.start) args.gte = args.start
   if (args.end) args.lte = args.end
 
+  var valueEncoding = args.valueEncoding || 'json'
+
   if (args.values || args.keys) {
 
     if (args.values) args.keys = false;
@@ -35,8 +37,7 @@ module.exports = function(db, args) {
             items.push(data);
           }
         }
-        else if (!args.valueEncoding ||
-          args.valueEncoding == 'json') {
+        else if (valueEncoding === 'json') {
           process.stdout.write(JSON.stringify(data) + '\n');
         }
         else {
@@ -63,9 +64,7 @@ module.exports = function(db, args) {
         if (++count > limit) {
           return process.exit()
         }
-        if (!args.valueEncoding ||
-          args.valueEncoding == 'json') {
-
+        if (valueEncoding === 'json') {
           return process.stdout.write(
             JSON.stringify(data) + '\n'
           );

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -93,6 +93,9 @@ module.exports = function(db, args) {
     db.del(args.key || args.del, printAndExit);
   }
   else if (args.batch) {
+    if (args.batch[0] !== '[') {
+      args.batch = require('fs').readFileSync(args.batch).toString()
+    }
     var batch = JSON.parse(args.batch);
     db.batch(batch, printAndExit);
   }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -8,7 +8,8 @@
 var Tabulate = require('tabulate');
 var print = require('./print');
 var printAndExit = require('./print_and_exit');
-var minimatch = require("minimatch");
+var minimatch = require('minimatch');
+var path = require('path');
 
 var hasStreamArg = function(args) {
   return args.all || args.values || args.keys || args.match || args.length
@@ -16,8 +17,19 @@ var hasStreamArg = function(args) {
 
 module.exports = function(db, args) {
 
-  if (!hasStreamArg(args) && (args.start || args.end || args.limit)) {
+  if (!hasStreamArg(args) && (args.start || args.end || args.limit || args.map)) {
     args.all = true
+  }
+
+  var mapFn
+  if (args.map) {
+    try {
+      mapFn = require(path.resolve(args.map))
+    }
+    catch (err) {
+      if (err.code !== 'MODULE_NOT_FOUND') throw err
+      mapFn = eval(args.map)
+    }
   }
 
   if (hasStreamArg(args)) {
@@ -45,7 +57,7 @@ module.exports = function(db, args) {
 
 
     var tabulate;
-    if (keys && !args.line) {
+    if (keys && !args.line && !args.map) {
       tabulate = Tabulate(process.stdout);
       var items = [];
     }
@@ -66,6 +78,11 @@ module.exports = function(db, args) {
         if (args.match) {
           if (keys) data = data.key;
           if (values) data = data.value;
+        }
+
+        if (args.map) {
+          data = mapFn(data)
+          if (data == null) return
         }
 
         if (tabulate) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -53,12 +53,6 @@ module.exports = function(db, args) {
         process.exit(0);
       });
   }
-  else if (args.put) {
-    db.put(args.key || args.put, args.value, printAndExit)
-  }
-  else if (args.get) {
-    db.get(args.key || args.get, printAndExit)
-  }
   else if (args.match) {
     var limit = typeof args.limit === 'number' ? args.limit : Infinity
     var count = 0
@@ -88,12 +82,18 @@ module.exports = function(db, args) {
       .on('error', print)
       .on('end', process.exit);
   }
-  else if (args.batch) {
-    var batch = JSON.parse(args.batch)
-    db.batch(batch, printAndExit)
+  else if (args.put) {
+    db.put(args.key || args.put, args.value, printAndExit)
+  }
+  else if (args.get) {
+    db.get(args.key || args.get, printAndExit)
   }
   else if (args.del) {
     db.del(args.key || args.del, printAndExit)
+  }
+  else if (args.batch) {
+    var batch = JSON.parse(args.batch)
+    db.batch(batch, printAndExit)
   }
   else {
     printAndExit(new Error('No valid command'));

--- a/lib/db.js
+++ b/lib/db.js
@@ -11,6 +11,13 @@ module.exports = function(args) {
   //if (!args.keyEncoding) {
   //  args.keyEncoding = bytewise
   //}
-  return level(args.path, args)
+
+  // Ignore args that aren't meant to be database options
+  // Start by cloning the args object so that those changes
+  // don't propagate anyware else
+  dbArgs = JSON.parse(JSON.stringify(args))
+  delete dbArgs.limit
+
+  return level(dbArgs.path, dbArgs)
 }
 

--- a/lib/location.js
+++ b/lib/location.js
@@ -4,9 +4,28 @@
  * tries to find the location of the database.
  *
  */
+
 module.exports = function (argv) {
 
   var location = typeof argv.location === 'string';
-  argv.path = location && argv.location || argv._[0] || process.cwd();
+  argv.path = location && argv.location || argv._[0];
+  if (!argv.path) {
+    if (cwdIsADatabase()) {
+      argv.path = process.cwd();
+    }
+    else {
+      console.error('no database found');
+      return process.exit(1);
+    };
+  };
+};
+
+function cwdIsADatabase () {
+  try {
+    var CURRENT = require('fs').readFileSync('./CURRENT').toString();
+    return CURRENT.split('-')[0] === 'MANIFEST';
+  } catch (err) {
+    return false;
+  };
 };
 

--- a/lib/location.js
+++ b/lib/location.js
@@ -5,10 +5,21 @@
  *
  */
 
-module.exports = function (argv) {
+ var prompt = require('cli-prompt')
+
+module.exports = function (argv, cb) {
 
   var location = typeof argv.location === 'string';
-  argv.path = location && argv.location || argv._[0];
+  argv.path = location && argv.location || argv._[0] || process.cwd();
+
+  if (isDatabasePath(argv.path)) {
+    cb();
+  }
+  else {
+    requestConfirmation(argv.path, cb);
+  }
+
+
   if (!argv.path) {
     if (cwdIsADatabase()) {
       argv.path = process.cwd();
@@ -20,12 +31,25 @@ module.exports = function (argv) {
   };
 };
 
-function cwdIsADatabase () {
+function isDatabasePath (path) {
   try {
-    var CURRENT = require('fs').readFileSync('./CURRENT').toString();
+    var testFilePath = require('path').resolve(path) + '/CURRENT'
+    var CURRENT = require('fs').readFileSync(testFilePath).toString();
     return CURRENT.split('-')[0] === 'MANIFEST';
   } catch (err) {
-    return false;
+    if (err.code === 'ENOENT') return false
+    throw err
   };
 };
+
+function requestConfirmation (path, cb) {
+  prompt(`do you really want to create a new database in ${path}? [y/N]`, function (val) {
+    if (val.toLowerCase().trim() === 'y') {
+      cb();
+    }
+    else {
+      process.exit(1);
+    }
+  })
+}
 

--- a/lib/print_and_exit.js
+++ b/lib/print_and_exit.js
@@ -1,0 +1,14 @@
+/*
+ *
+ * print_and_exit.js
+ * A wrapper of print for the CLI that exits with a non-zero code
+ * in case of errors
+ *
+ */
+ var print = require('./print');
+
+ module.exports = function printAndExit(err, val) {
+  print(err, val)
+  var exitCode = err == null ? 0 : 1
+  process.exit(exitCode)
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "minimist": "^1.1.0",
     "multilevel": "^7.3.0",
     "rc": "^0.5.4",
+    "split": "^1.0.1",
     "tabulate": "^1.0.0",
     "xtend": "^4.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "cli-prompt": "^0.6.0",
     "level": "^1.3.0",
     "level-party": "^3.0.4",
-    "minimatch": "^2.0.1",
+    "minimatch": "^3.0.4",
     "minimist": "^1.1.0",
     "multilevel": "^7.3.0",
     "rc": "^0.5.4",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "homepage": "https://github.com/hij1nx/lev",
   "dependencies": {
     "bytewise": "^1.1.0",
+    "cli-prompt": "^0.6.0",
     "level": "^1.3.0",
     "level-party": "^3.0.4",
     "minimatch": "^2.0.1",


### PR DESCRIPTION
[this is a the same as #58 but with a different branch to be able to customize [master](https://github.com/maxlath/lev/tree/master)]

hi! I was struggling to use the CLI, so I dug into the code and went into refactoring berserk mode: it might be a lot of changes, so feel welcome to merge or cherry-pick whatever make sense to you :)

**Summary**:
* [documented CLI commands](https://github.com/maxlath/lev#cli-commands)
* renamed the `--createReadStream` command into [`--all`](https://github.com/maxlath/lev#--all) to distinct it from `--keys` and `--values` streams
* [Added a `--line` mode for `--keys`](https://github.com/maxlath/lev#--line)
* [Added a `--length` command](https://github.com/maxlath/lev#--length)
* [Added a `--map` command](https://github.com/maxlath/lev#--map)
* [Fixed the `--batch` option and let it take operations from a file](https://github.com/maxlath/lev#--batch)
* [made `--all` and `--batch` be fit to be used as import/export tools](https://github.com/maxlath/lev#import--export)
* [Merged CLI stream commands code to mutualize logic](https://github.com/maxlath/lev/blob/master/lib/cli.js#L15-L86)

[Edit: those changes are now part of [lev2](https://github.com/maxlath/lev2)]